### PR TITLE
fix(safe/gcp-safe): use jq -n for record_check JSON + exact-match SA lookup

### DIFF
--- a/safe/gcp-safe/verify-kms-enhanced.sh
+++ b/safe/gcp-safe/verify-kms-enhanced.sh
@@ -76,12 +76,21 @@ cleanup_temp_dir() {
 }
 
 # 记录检查结果
+# 用 jq -n 构造 JSON 对象,避免 message/detail 含双引号时把 JSON 行打坏
 record_check() {
     local status="$1"
     local message="$2"
     local detail="${3:-}"
-    
-    CHECK_RESULTS+=("{\"status\":\"$status\",\"message\":\"$message\",\"detail\":\"$detail\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}")
+
+    local entry
+    entry=$(jq -n \
+        --arg status "$status" \
+        --arg message "$message" \
+        --arg detail "$detail" \
+        --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        '{status: $status, message: $message, detail: $detail, timestamp: $timestamp}')
+
+    CHECK_RESULTS+=("$entry")
 }
 
 # 打印信息
@@ -458,11 +467,12 @@ check_service_account_permissions() {
         local has_encrypt=false
         local has_decrypt=false
         
-        if echo "$encrypters" | grep -qF "$sa"; then
+        # -xF = 整行精确匹配:避免短 SA 名误中长 SA 的子串(grep -qF 默认子串匹配)
+        if echo "$encrypters" | grep -qxF "$sa"; then
             has_encrypt=true
         fi
-        
-        if echo "$decrypters" | grep -qF "$sa"; then
+
+        if echo "$decrypters" | grep -qxF "$sa"; then
             has_decrypt=true
         fi
         


### PR DESCRIPTION
## Summary

Two real bugs in `safe/gcp-safe/verify-kms-enhanced.sh` that surface in normal use:

1. **`record_check()` built JSON rows by bash string interpolation.** Any `message` or `detail` containing a `"` (very common in `gcloud` errors — e.g. `API has not been used in project "proj-a" or enabled`) corrupts the row, and `generate_json_report` then emits invalid JSON that no parser can read. Replaced with `jq -n + --arg` so `jq` handles all escaping.

2. **`check_service_account_permissions()` used `grep -qF` for SA lookup.** `-F` is substring match by default, so a shorter SA email accidentally matched longer IAM entries with the same tail and falsely reported the SA as authorised. Switched to `grep -qxF` (full-line exact match).

Both changes keep the existing structure, flags, exit codes, and report formats. Behaviour outside those two functions is unchanged.

## Verification

- `bash -n` passes — no syntax errors.
- Smoke test: round-trip two `record_check` rows (one with embedded `"`) through the new `jq -n` path → `json.load()` succeeds and the message text round-trips exactly.
- `set -euo pipefail` and `pipefail` semantics preserved.

## Diff

```diff
@@ record_check @@
- CHECK_RESULTS+=("{\"status\":\"$status\",\"message\":\"$message\",...}")
+ local entry
+ entry=$(jq -n \
+     --arg status "$status" \
+     --arg message "$message" \
+     --arg detail "$detail" \
+     --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+     '{status: $status, message: $message, detail: $detail, timestamp: $timestamp}')
+ CHECK_RESULTS+=("$entry")

@@ check_service_account_permissions (SA lookup) @@
- if echo "$encrypters" | grep -qF "$sa"; then
+ # -xF = 整行精确匹配:避免短 SA 名误中长 SA 的子串
+ if echo "$encrypters" | grep -qxF "$sa"; then
- if echo "$decrypters" | grep -qF "$sa"; then
+ if echo "$decrypters" | grep -qxF "$sa"; then
```

## Out of scope (deliberately not changed)

Other smaller items spotted during review but **not** fixed in this PR to keep scope minimal:

- `set +e` style inconsistency in `parse_arguments` (validation block)
- `generate_report` falls through to markdown when `--output-format=text`
- Heading emoji in markdown report

Happy to follow up with a separate PR if you want any of those touched.